### PR TITLE
fix: align package scope with npm org

### DIFF
--- a/.claude/INSTALL.md
+++ b/.claude/INSTALL.md
@@ -17,7 +17,7 @@ Adds the `narrate` skill to Claude Code so you can say "narrate this folder" and
 
 3. **Install the CLI** (required for the skill to build stories):
    ```bash
-   npm install -g @biolytics-ai/diascope
+   npm install -g @biolytics.ai/diascope
    ```
 
 4. **Restart Claude Code.**
@@ -58,5 +58,5 @@ cd ~/.claude/diascope && git pull
 ```bash
 rm ~/.agents/skills/diascope
 rm -rf ~/.claude/diascope
-npm uninstall -g @biolytics-ai/diascope
+npm uninstall -g @biolytics.ai/diascope
 ```

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -23,7 +23,7 @@ Or manually:
 
 3. **Install the CLI:**
    ```bash
-   npm install -g @biolytics-ai/diascope
+   npm install -g @biolytics.ai/diascope
    ```
 
 4. **Restart Codex.**
@@ -49,5 +49,5 @@ cd ~/.codex/diascope && git pull
 ```bash
 rm ~/.agents/skills/diascope
 rm -rf ~/.codex/diascope
-npm uninstall -g @biolytics-ai/diascope
+npm uninstall -g @biolytics.ai/diascope
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Package CI](https://github.com/Biolytics-AI/DiaScope/actions/workflows/ci.yml/badge.svg)](https://github.com/Biolytics-AI/DiaScope/actions/workflows/ci.yml)
 [![Docs](https://github.com/Biolytics-AI/DiaScope/actions/workflows/docs.yml/badge.svg)](https://github.com/Biolytics-AI/DiaScope/actions/workflows/docs.yml)
-[![npm version](https://img.shields.io/npm/v/%40biolytics-ai%2Fdiascope)](https://www.npmjs.com/package/@biolytics-ai/diascope)
+[![npm version](https://img.shields.io/npm/v/%40biolytics.ai%2Fdiascope)](https://www.npmjs.com/package/@biolytics.ai/diascope)
 [![Docs Site](https://img.shields.io/badge/docs-diascope.biolytics.ai-06E1EC)](https://diascope.biolytics.ai)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-002451)](https://nodejs.org/)
 
@@ -44,7 +44,7 @@ See the live example and feature docs at `https://diascope.biolytics.ai`.
 ## Install
 
 ```bash
-npm install -g @biolytics-ai/diascope
+npm install -g @biolytics.ai/diascope
 ```
 
 ---
@@ -205,8 +205,8 @@ You can also browse the same example in the docs at `https://diascope.biolytics.
 Embed in a framework or custom shell:
 
 ```js
-import { DiaScopeViewer } from "@biolytics-ai/diascope";
-import { parseStoryFile, storyToViewerOptions } from "@biolytics-ai/diascope/story";
+import { DiaScopeViewer } from "@biolytics.ai/diascope";
+import { parseStoryFile, storyToViewerOptions } from "@biolytics.ai/diascope/story";
 
 const story = parseStoryFile(yamlString);
 const viewer = new DiaScopeViewer({
@@ -227,7 +227,7 @@ DiaScope releases are published from GitHub, not from local machines.
 1. Open a PR into `main`.
 2. Merge only after `build-and-test` and `build-docs` pass.
 3. Create and push a version tag like `v0.1.0`.
-4. GitHub Actions publishes `@biolytics-ai/diascope` to npm and creates the matching GitHub Release.
+4. GitHub Actions publishes `@biolytics.ai/diascope` to npm and creates the matching GitHub Release.
 
 Local `npm publish` should only be used for dry-runs and debugging.
 

--- a/docs-site/src/content/docs/getting-started.mdx
+++ b/docs-site/src/content/docs/getting-started.mdx
@@ -11,7 +11,7 @@ description: Install DiaScope, scaffold a story file, and build your first narra
 ## Install the CLI
 
 ```bash
-npm install -g @biolytics-ai/diascope
+npm install -g @biolytics.ai/diascope
 ```
 
 ## 1. Write a D2 diagram

--- a/docs-site/src/content/docs/guides/ai-agents.mdx
+++ b/docs-site/src/content/docs/guides/ai-agents.mdx
@@ -23,7 +23,7 @@ The `.d2` and `.story.yaml` are the canonical source files. The `.html` is the s
 git clone https://github.com/Biolytics-AI/DiaScope.git ~/.claude/diascope
 mkdir -p ~/.agents/skills
 ln -s ~/.claude/diascope/skills ~/.agents/skills/diascope
-npm install -g @biolytics-ai/diascope
+npm install -g @biolytics.ai/diascope
 ```
 
 Then restart Claude Code.
@@ -50,7 +50,7 @@ Manual install:
 git clone https://github.com/Biolytics-AI/DiaScope.git ~/.codex/diascope
 mkdir -p ~/.agents/skills
 ln -s ~/.codex/diascope/skills ~/.agents/skills/diascope
-npm install -g @biolytics-ai/diascope
+npm install -g @biolytics.ai/diascope
 ```
 
 Then restart Codex.

--- a/docs-site/src/content/docs/reference/javascript-api.mdx
+++ b/docs-site/src/content/docs/reference/javascript-api.mdx
@@ -6,8 +6,8 @@ description: Embed the DiaScope viewer in a custom shell or application.
 ## Import the viewer
 
 ```js
-import { DiaScopeViewer } from "@biolytics-ai/diascope";
-import { parseStoryFile, storyToViewerOptions } from "@biolytics-ai/diascope/story";
+import { DiaScopeViewer } from "@biolytics.ai/diascope";
+import { parseStoryFile, storyToViewerOptions } from "@biolytics.ai/diascope/story";
 
 const story = parseStoryFile(yamlString);
 const viewer = new DiaScopeViewer({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@biolytics-ai/diascope",
+  "name": "@biolytics.ai/diascope",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@biolytics-ai/diascope",
+      "name": "@biolytics.ai/diascope",
       "version": "0.1.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@biolytics-ai/diascope",
+  "name": "@biolytics.ai/diascope",
   "version": "0.1.0",
   "description": "Turn D2 diagrams into narrated interactive stories",
   "homepage": "https://diascope.biolytics.ai",

--- a/skills/narrate/SKILL.md
+++ b/skills/narrate/SKILL.md
@@ -19,7 +19,7 @@ diascope --version 2>/dev/null || echo "NOT INSTALLED"
 
 If not installed:
 ```bash
-npm install -g @biolytics-ai/diascope
+npm install -g @biolytics.ai/diascope
 ```
 
 ---


### PR DESCRIPTION
## Summary
- change the published package scope to match the existing npm org `@biolytics.ai`
- update install/import docs and agent skill instructions to the new scope
- keep the GitHub-driven npm release flow intact

## Verification
- npm run build
- npm test
- npm publish --access public --dry-run
